### PR TITLE
Fix for issue #69

### DIFF
--- a/types/SvelteInternal.d.ts
+++ b/types/SvelteInternal.d.ts
@@ -1,5 +1,7 @@
+import type { SvelteComponentTyped } from "svelte";
+
 // eslint-disable-next-line @typescript-eslint/ban-types
-export declare class LocalComponent<Props = {}, Slots = {}> {
+export declare class LocalComponent<Props = {}, Slots = {}> extends SvelteComponentTyped<Props> {
 	// eslint-disable-next-line camelcase
 	$$prop_def: Props;
 


### PR DESCRIPTION
Fixes the issue where imported svelte components cause the editor to throw the following error:

“Argument of type 'typeof Router' is not assignable to parameter of type 'ConstructorOfATypedSvelteComponent'”