### PR TITLE
Fixed typings: `location.state` may be null

### DIFF
--- a/types/NavigatorLocation.d.ts
+++ b/types/NavigatorLocation.d.ts
@@ -21,7 +21,7 @@ interface NavigatorLocation<State extends AnyObject = AnyObject> {
 	/**
 	 * An arbitrary object, that has been pushed to the history stack.
 	 */
-	state: State;
+	state: State | null;
 }
 
 export default NavigatorLocation;


### PR DESCRIPTION
If no `state` object was added, the property will be `null`